### PR TITLE
style: :iphone: 로그인 화면 퍼블리싱

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const router = useRouter();
+
+  const handleNaverLogin = () => {
+    // TODO: 네이버 OAuth 연동 시 이 부분에 redirect 로직
+    alert("네이버 로그인 연동 예정입니다. 일단 회원가입 화면으로 이동합니다.");
+    router.push("/auth/signup");
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col px-6 py-8">
+      {/* 상단 뒤로가기 / 나중에 할래요 */}
+      <header className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="text-xs text-gray-500"
+        >
+          뒤로
+        </button>
+      </header>
+
+      {/* 중앙 로고 + 카피 (화면 가운데 쪽에 오도록 flex-1 부여) */}
+      <section className="flex-1 flex flex-col items-center justify-center text-center gap-3">
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-xl font-semibold text-gray-900">Carefit</span>
+        </div>
+        <h1 className="text-xl font-bold text-gray-900">
+          한 손에 관리하는 운동의 모든 것
+        </h1>
+        <p className="text-xs text-gray-500">
+          간편 로그인으로 오늘의 운동, 체육동호회, 대회 정보를 한 번에
+          받아보세요.
+        </p>
+      </section>
+
+      {/* 하단 로그인 버튼 + 약관 안내 */}
+      <footer className="flex flex-col gap-3 pb-4">
+        <div className="flex flex-col gap-2">
+          {/* 네이버 로그인 버튼 */}
+          <button
+            type="button"
+            onClick={handleNaverLogin}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-[#03C75A] py-3 text-sm font-semibold text-white shadow-sm"
+          >
+            {/* 네이버 로고 자리 (아이콘/이미지로 교체 예정) */}
+            <span className="flex h-5 w-5 items-center justify-center rounded bg-white/90 text-xs font-bold text-[#03C75A]">
+              N
+            </span>
+            네이버로 계속하기
+          </button>
+
+          {/* (개발용) 건너뛰기 버튼 */}
+          <button
+            type="button"
+            onClick={() => router.push("/home")}
+            className="w-full rounded-xl border border-gray-200 bg-gray-50 py-3 text-xs text-gray-600"
+          >
+            (개발용) 로그인 건너뛰고 홈으로 이동
+          </button>
+        </div>
+
+        {/* 약관 안내 문구 */}
+        <p className="text-[10px] text-center text-black">
+          로그인 시 서비스 이용약관, 개인정보 처리방침에 동의하게 됩니다.
+        </p>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
## 연관 이슈

close #7 

<br/>

## 📁 작업 내용

- Carefit 로그인 진입 화면을 신규로 구현했습니다.
- 중앙에는 서비스 핵심 카피를 배치하고, 하단에는 네이버 간편 로그인 버튼 및 개발용 건너뛰기 버튼을 추가했습니다.
- 레이아웃은 모바일 기준으로 상단(뒤로가기) / 중앙(카피) / 하단(로그인 버튼) 구조로 정렬하여 UX 흐름을 개선했습니다.

<br/>

## 🖥 구현 결과 (선택)

<img width="413" height="941" alt="image" src="https://github.com/user-attachments/assets/f48a8648-53b2-41b6-a692-83d6f0a6fddf" />


<br/>

## ✔ 리뷰 요구사항

- 네이버 로그인 버튼 영역의 스타일(색상, 여백, 라운딩)과 실제 디자인 시안과의 일치 여부 확인 요청드립니다.
- “로그인 건너뛰고 홈으로 이동” 버튼을 개발 환경에서만 노출하는 방식이 적절한지 의견 부탁드립니다.
- 레이아웃 구조가 이후 추가될 SNS 로그인/이메일 로그인 등 확장성 측면에서 적합한지 검토해주시면 좋겠습니다.

<br/>

## 📁 기타 사항

- 현재 네이버 로그인 기능은 실제 OAuth 연동이 아닌 임시 alert + 페이지 이동 처리입니다.
추후 OAuth 클라이언트 등록 후 redirect 로직으로 교체가 필요합니다.

- 디자인 확정 전이라 로고는 텍스트 형태로 사용 중입니다. SVG 적용 시 클래스/여백 재조정이 필요할 수 있습니다.
<br/> ex) 더미 데이터를 넣어서 기능 구현한 상태입니다!

<br/>
