### PR TITLE
✨feat: set authorization token

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -2,10 +2,11 @@
 
 import { HomeCard } from "@/components/HomeCard";
 import { useUser } from "@/hooks/useUser";
+import { useAuthStore } from "@/lib/zustand/useAuthStore";
 
 export default function HomePage() {
-  const { name } = useUser();
-  const userName = name ?? "케어핏";
+  // const { name } = useUser();
+  const user = useAuthStore(state => state.user);
 
   return (
     <div className="relative ">
@@ -22,7 +23,7 @@ export default function HomePage() {
               Carefit
             </h1>
             <p className="mt-2 text-xs text-black-50">
-              {userName}님을 위한 추천 운동 라이프
+              {user?.name}님을 위한 추천 운동 라이프
             </p>
           </div>
         </header>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,74 @@
 import type { Metadata } from "next";
-import Script from "next/script";
+import { cookies } from "next/headers";
 import "./globals.css";
 import { QueryProvider } from "@/lib/queryClient";
 import { SWRProvider } from "@/lib/swr";
 import BottomNavigator from "@/components/BottomNavigator";
+import { AuthInitializer } from "@/components/AuthInitializer";
+import { User } from "@/lib/utils/types";
+
+// AuthState에서 함수 필드를 제외한 순수 데이터 타입 정의 (Next.js SSR 최적화)
+interface InitialAuthData {
+  user: User | null;
+  accessToken: string | null;
+  isLoggedIn: boolean;
+}
 
 export const metadata: Metadata = {
   title: "KSPO Webapp",
   description: "운동 루틴 & 건강 관리 + 카풀 웹앱",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // 1. 서버 환경 변수에서 테스트 토큰을 읽어옵니다.
+  // NEXT_PUBLIC_ 접두사는 서버에서도 접근 가능합니다.
+  const TEST_TOKEN = process.env.NEXT_PUBLIC_TEST_ACCESS_TOKEN || null;
+  const TEST_USER_NAME = process.env.NEXT_PUBLIC_TEST_USER_NAME || "테스터";
+  const TEST_USER_ID = process.env.NEXT_PUBLIC_TEST_USER_ID || "TEST_ID";
+
+  // 2. 쿠키에서 실제 토큰을 읽어옵니다.
+  const cookieStore = cookies();
+  const cookieAccessToken = (await cookieStore).get('access_token')?.value || null;
+
+  // 3. 토큰 우선 순위 결정: 테스트 토큰이 있으면 쿠키보다 우선합니다.
+  const finalAccessToken = TEST_TOKEN || cookieAccessToken;
+  
+  // 4. User 객체 결정 (실제 운영 시 API 호출 필요, 테스트/쿠키 기반 분기)
+  let initialUser: User | null = null;
+  if (finalAccessToken) {
+      // 토큰이 있다면, 테스트 환경 변수를 사용하여 더미 User 객체를 생성합니다.
+      // 실제 운영 환경에서는 API 호출 후 User 객체를 이곳에 할당해야 합니다.
+      initialUser = { 
+          id: TEST_USER_ID, 
+          email: `${TEST_USER_ID}@test.com`,
+          name: TEST_USER_NAME,
+          role: "USER"
+          // User 타입에 필요한 나머지 필드를 채워야 함
+      } as User; 
+  }
+
+  // 5. AuthInitializer에 전달할 초기 상태 구성 (함수 필드 제외)
+  const initialAuthState: InitialAuthData = {
+    accessToken: finalAccessToken,
+    user: initialUser,
+    isLoggedIn: !!finalAccessToken,
+  };
+
   return (
     <html lang="ko">
       <body>
         <QueryProvider>
           <SWRProvider>
-            <div className="app-mobile-shell">
-              {children}
-              <BottomNavigator />
-            </div>
+            <AuthInitializer initialState={initialAuthState}>
+              <div className="app-mobile-shell">
+                {children}
+                <BottomNavigator />
+              </div>
+            </AuthInitializer>
           </SWRProvider>
         </QueryProvider>
       </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,13 +4,15 @@ import { useRouter } from "next/navigation";
 import { setDummyLogin } from "@/hooks/useAuth";
 import Image from "next/image";
 import { setDummyUserName } from "@/hooks/useUser";
+import { getNaverLoginUrl } from "@/lib/utils/authUrl/getNaverLoginUrl"
 
 export default function LoginPage() {
   const router = useRouter();
 
   const handleNaverLogin = () => {
-    alert("네이버 로그인 연동 예정입니다. 일단 회원가입 화면으로 이동합니다.");
-    router.push("/onboarding/init");
+    // alert 제거 및 실제 OAuth 인증 URL로 리디렉션
+    const naverAuthUrl = getNaverLoginUrl();
+    window.location.href = naverAuthUrl; // 브라우저 레벨에서 리디렉션
   };
 
   const handleSkip = () => {
@@ -48,7 +50,7 @@ export default function LoginPage() {
       {/* 하단 버튼 영역 - 이미지 바로 아래에 붙음 */}
       <footer className="flex flex-col items-center gap-3 pb-4">
         <div className="flex w-full max-w-[300px] flex-col gap-2">
-          {/* 네이버 로그인 */}
+          {/* 네이버 로그인 버튼은 handleNaverLogin 함수 호출 */}
           <button
             type="button"
             onClick={handleNaverLogin}

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRef, ReactNode } from 'react';
+import { useAuthStore, AuthState } from '@/lib/zustand/useAuthStore'; 
+
+interface Props {
+  // 서버에서 읽어온 초기 상태를 담는 Prop
+  initialState: AuthState;
+  children: ReactNode;
+}
+
+/**
+ * 서버 컴포넌트에서 읽은 인증 상태를 Zustand 스토어에 주입합니다 (Hydration).
+ * Next.js SSR과 CSR 상태를 동기화하는 핵심 컴포넌트입니다.
+ */
+export function AuthInitializer({ initialState, children }: Props) {
+  // 컴포넌트가 마운트될 때마다 상태가 초기화되는 것을 막기 위해 useRef 사용
+  const initialized = useRef(false);
+
+  // 중요: 컴포넌트가 처음 렌더링될 때 (Hydration 시) 단 한 번만 실행되도록 보장
+  if (!initialized.current) {
+    // 서버에서 받은 초기 상태(토큰 유무, 유저 정보)를 Zustand 스토어에 주입
+    // 이 작업을 통해 CSR(클라이언트) 코드 실행 전 인증 상태가 미리 설정됩니다.
+    useAuthStore.setState(initialState);
+    initialized.current = true;
+  }
+
+  // Zustand 상태가 주입된 후, 자식 컴포넌트를 렌더링
+  return <>{children}</>;
+}

--- a/src/lib/utils/authUrl/getNaverLoginUrl.ts
+++ b/src/lib/utils/authUrl/getNaverLoginUrl.ts
@@ -1,0 +1,16 @@
+import { env } from "@/lib/utils/env";
+
+/**
+ * 네이버 소셜 로그인을 시작하기 위한 백엔드 인증 URL을 구성합니다.
+ * @returns {string} 완성된 리디렉션 URL
+ */
+export const getNaverLoginUrl = (): string => {
+    // env.API_BASE_URL (예: http://localhost:8080)을 사용합니다.
+    const baseUrl = env.API_BASE_URL; 
+    
+    // 백엔드 개발자가 지정한 OAuth2 인증 시작 경로를 붙입니다.
+    // 'ouath2' 오타가 자주 발생하므로 주의해야 합니다. (oauth2로 가정)
+    const oauthPath = "/oauth2/authorization/naver"; 
+    
+    return `${baseUrl}${oauthPath}`;
+};

--- a/src/lib/utils/env.ts
+++ b/src/lib/utils/env.ts
@@ -1,6 +1,6 @@
 export const env = {
   API_BASE_URL:
-    process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.example.com",
+    process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://54.180.125.38:8080",
   GOOGLE_MAPS_API_KEY:
     process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "DUMMY_GOOGLE_KEY",
   KAKAO_MAPS_API_KEY:

--- a/src/lib/zustand/useAuthStore.ts
+++ b/src/lib/zustand/useAuthStore.ts
@@ -3,16 +3,48 @@
 import { create } from "zustand";
 import type { User } from "@/lib/utils/types";
 
-interface AuthState {
+// User 객체와 AccessToken이 nullable임을 정의합니다.
+export interface AuthState {
   user: User | null;
   accessToken: string | null;
-  setAuth: (user: User, token: string) => void;
-  clearAuth: () => void;
+  isLoggedIn: boolean; 
+  
+  // 클라이언트 액션
+  setAuth?: (user: User, token: string) => void;
+  clearAuth?: () => void;
+  
+  // 추가: SSR/Hydration을 위한 초기화 함수
+  initializeAuth?: (user: User | null, token: string | null) => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+// 초기 상태
+const initialAuthState = {
   user: null,
   accessToken: null,
-  setAuth: (user, token) => set({ user, accessToken: token }),
-  clearAuth: () => set({ user: null, accessToken: null }),
+  isLoggedIn: false,
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  ...initialAuthState,
+
+  // 1. SSR/Hydration을 위한 초기화 함수 (서버 데이터를 클라이언트에 주입)
+  initializeAuth: (user, token) => {
+    // 이 함수는 서버 컴포넌트에서 읽은 초기 데이터를 클라이언트에서 단 한 번 주입할 때 사용됩니다.
+    set({
+      user: user,
+      accessToken: token,
+      isLoggedIn: !!token,
+    });
+  },
+
+  // 2. 클라이언트 액션 (로그인 성공 시)
+  setAuth: (user, token) => 
+    set({ 
+      user, 
+      accessToken: token, 
+      isLoggedIn: true // 로그인 성공 시 true 설정
+    }),
+
+  // 3. 클라이언트 액션 (로그아웃 시)
+  clearAuth: () => set(initialAuthState),
 }));


### PR DESCRIPTION
## 연관 이슈

close #27 

<br/>


## 📁 작업 내용

이번 PR은 네이버 소셜 로그인 연동이 현재 불가능한 상황에서, **테스트 환경 구축 및 SSR/CSR 인증 상태 동기화**를 목표로 진행했습니다. 백엔드에서 제공한 `TEST_ACCESS_TOKEN`을 활용하여 클라이언트와 서버 간의 인증 상태를 일치시키고, 추후 API 연동을 위한 기반을 마련했습니다.

주요 변경 사항은 다음과 같습니다.

  * **환경 변수 설정**: `.env.local`에 `NEXT_PUBLIC_TEST_ACCESS_TOKEN` 및 테스트용 더미 사용자 정보를 등록했습니다.
  * **Zustand 스토어 구조 개선**: `useAuthStore`에 `isLoggedIn` 상태와 초기화 함수(`initializeAuth`)를 추가하여 SSR Hydration 과정에 적합하도록 구조를 변경했습니다.
  * **인증 상태 주입 (Server & Client)**:
      * **Server (`layout.tsx`)**: 쿠키와 환경 변수를 확인하여 토큰 우선순위(Test Token \> Cookie)에 따라 초기 상태(`initialState`)를 구성했습니다.
      * **Client (`AuthInitializer.tsx`)**: 서버로부터 전달받은 초기 상태를 클라이언트 진입 시점에 스토어에 주입(Hydrate)하도록 구현했습니다.
  * **토큰 확인용 UI**: `UserDisplay` 컴포넌트를 통해 주입된 토큰과 사용자 정보가 화면에 정상적으로 출력되는지 검증했습니다.

<br>

## 🖥 구현 결과 (선택)

> *(여기에 `UserDisplay` 컴포넌트를 통해 화면에 TEST\_TOKEN과 더미 유저 정보가 출력된 스크린샷을 첨부해주세요)*

<br>

## ✔ 리뷰 요구사항

다음 로직을 중점적으로 확인 부탁드립니다.

1.  **인증 상태 초기화 흐름**: `app/layout.tsx`에서 구성한 `initialState`가 `AuthInitializer`를 통해 `useAuthStore`로 문제없이 주입되는지 확인해주세요.
2.  **토큰 우선순위 로직**: 개발 환경에서 `TEST_ACCESS_TOKEN`이 존재할 경우, 쿠키보다 우선하여 적용되는 로직이 의도대로 동작하는지 검토 부탁드립니다.

<br>

## 📁 기타 사항

  * ⚠️ **주의**: `NEXT_PUBLIC_TEST_ACCESS_TOKEN`을 사용하는 로직은 개발 편의를 위한 것으로, **실제 운영 환경 배포 시 반드시 제거**되어야 합니다.
  * 현재 표시되는 유저 정보는 `.env.local`의 더미 데이터입니다. 추후 `accessToken`을 활용한 실제 API 연동(`api/v1/users/me`)을 통해 실제 유저 객체를 가져오도록 수정할 예정입니다.
  * Axios 인터셉터가 Zustand의 토큰을 읽도록 설정되어 있으므로, 다음 작업부터는 즉시 API 호출 테스트가 가능합니다.